### PR TITLE
Security on ccm command and parameter class

### DIFF
--- a/libs/command.js
+++ b/libs/command.js
@@ -1,4 +1,5 @@
 const Errors = require("./errors.js");
+const Parameter = require("./parameter.js").Parameter;
 
 /**
  * TODO : add class command with getCommand and get Parameters
@@ -35,8 +36,13 @@ module.exports = {
          * Returns the command parameters
          **/
         getCommandParameters() {
-            var res = this.commandLine.split(" ");
-            res.shift();
+            var params = this.commandLine.split(" ");
+            params.shift();
+            var res = [];
+            for (var i = 0; i < params.length; i++){
+                let current = params[i];
+                res.push(new Parameter(current));
+            }
             return res;
         }
         

--- a/libs/parameter.js
+++ b/libs/parameter.js
@@ -1,0 +1,43 @@
+const Errors = require("./errors.js");
+
+module.exports = {
+    /**
+     * Parameter class
+     **/
+    Parameter : class {
+        /**
+         * Default constructor
+         * The parameter must not be undefined or empty
+         * @throws CommandGenerationError if the parameter is undefined
+         * @throw CommandEmptyError if no parameter is passed and the string is empty
+         **/
+        constructor(parameterstr) {
+            if(parameterstr == undefined) {
+                throw new Errors.CommandGenerationError("Parameter undefined !");
+            } else if (parameterstr.trim().length == 0) {
+                throw new Errors.CommandEmptyError("No parameter passed")
+            } else {
+                this.parameterName = parameterstr;
+            }
+        }
+        
+        /**
+         * Returns the parameter name
+         **/
+        getParameterName() {
+            return this.parameterName;
+        }
+        
+        /**
+         * Tests if the parameter is a mention
+         **/
+        isMention() {
+            if (this.parameterName.startsWith("<@")
+                && this.parameterName.endsWith(">")) {
+                    return true;
+                } else {
+                    return false;
+                }
+        }
+    }
+}

--- a/test/test_command.js
+++ b/test/test_command.js
@@ -1,6 +1,7 @@
 const assert = require("assert");
 const Command = require("./../libs/command.js").Command;
-const Errors = require("./../libs/errors.js");;
+const Parameter = require("./../libs/parameter.js").Parameter;
+const Errors = require("./../libs/errors.js");
 
 /**
  * Here is a skeleton for the various test methods
@@ -144,8 +145,8 @@ function testGetCommandParameters1() {
 function testGetCommandParameters2() {
     console.log("Processing to test the getCommandParameters method 2");
     let cmd = new Command("help param");
-    let expected = ["param"];
-    let result = cmd.getCommandParameters();
+    let expected = "param";
+    let result = cmd.getCommandParameters()[0].getParameterName();
     assert.deepEqual(result,expected);
 }
 
@@ -155,8 +156,30 @@ function testGetCommandParameters2() {
 function testGetCommandParameters3() {
     console.log("Processing to test the getCommandParameters method 3");
     let cmd = new Command("help param1 param2");
-    let expected = ["param1", "param2"];
-    let result = cmd.getCommandParameters();
+    let expected = [new Parameter("param1"), new Parameter("param2")];
+    let result = [cmd.getCommandParameters()[0], cmd.getCommandParameters()[1]];
+    assert.deepEqual(result,expected);
+}
+
+/**
+ * Tests the getCommandParameters return size method with one parameter
+ **/
+function testGetCommandParameters4() {
+    console.log("Processing to test the getCommandParameters method 4");
+    let cmd = new Command("help param");
+    let expected = 1;
+    let result = cmd.getCommandParameters().length;
+    assert.deepEqual(result,expected);
+}
+
+/**
+ * Tests the getCommandParameters method with at least 2 parameters
+ **/
+function testGetCommandParameters5() {
+    console.log("Processing to test the getCommandParameters method 5");
+    let cmd = new Command("help param1 param2");
+    let expected = 2;
+    let result = cmd.getCommandParameters().length;
     assert.deepEqual(result,expected);
 }
 
@@ -182,6 +205,8 @@ testGetCommandName3();
 testGetCommandParameters1();
 testGetCommandParameters2();
 testGetCommandParameters3();
+testGetCommandParameters4();
+testGetCommandParameters5();
 
 console.log("Main tests completed");
 

--- a/test/test_command.js
+++ b/test/test_command.js
@@ -81,7 +81,7 @@ function testCommandConstructor5() {
  * Test if a non-valid command builds with an error
  * The expected error should be a CommandEmptyError
  **/
-function testCommandConstructor5() {
+function testCommandConstructor6() {
     console.log("Processing to test the Command constructor with expecting an error 3");
     try {
         new Command("   ");
@@ -171,6 +171,7 @@ testCommandConstructor2();
 testCommandConstructor3();
 testCommandConstructor4();
 testCommandConstructor5();
+testCommandConstructor6();
 
 /** GetCommandName tests **/
 testGetCommandName1();

--- a/test/test_parameters.js
+++ b/test/test_parameters.js
@@ -1,0 +1,132 @@
+const assert = require("assert");
+const Parameter = require("./../libs/parameter.js").Parameter;
+const Errors = require("./../libs/errors.js");
+
+/**
+ * Here is a skeleton for the various test methods
+ * Just copy/paste and replace with your values
+ * 
+    function testskeleton() {
+        console.log("Processing to test the TESTSKELETON method");
+        
+        let expected = "MY_EXPECTED_VALUES";
+        let result = MY_FUNCTION_TO_TEST();
+        assert.deepEqual(result,expected);
+    }
+ *    
+**/
+
+/**
+ * Test if a valid parameter builds without any error
+ **/
+function testParameterConstructor1() {
+    console.log("Processing to test the Parameter constructor method 1");
+    new Parameter("-r");
+    //No try-catch because there should not be any errors
+}
+
+/**
+ * Test if a non-valid command builds with an error
+ * The expected error should be a CommandGenerationError
+ **/
+function testParameterConstructor2() {
+    console.log("Processing to test the Parameter constructor with expecting an error 2");
+    try {
+        new Parameter(undefined);
+    } catch (e) {
+        if (e instanceof Errors.CommandGenerationError) {
+            assert(true);
+            return;
+        }
+    }
+    assert(false);
+}
+
+/**
+ * Test if a non-valid command builds with an error
+ * The expected error should be a CommandEmptyError
+ **/
+function testParameterConstructor3() {
+    console.log("Processing to test the Parameter constructor with expecting an error 3");
+    try {
+        new Parameter("");
+    } catch (e) {
+        if (e instanceof Errors.CommandEmptyError) {
+            assert(true);
+            return;
+        }
+    }
+    assert(false);
+}
+
+/**
+ * Test if a non-valid command builds with an error
+ * The expected error should be a CommandEmptyError
+ **/
+function testParameterConstructor4() {
+    console.log("Processing to test the Parameter constructor with expecting an error 4");
+    try {
+        new Parameter("   ");
+    } catch (e) {
+        if (e instanceof Errors.CommandEmptyError) {
+            assert(true);
+            return;
+        }
+    }
+    assert(false);
+}
+
+/**
+ * Tests the getParameterName
+ **/
+function testGetParameterName1() {
+    console.log("Processing to test the Parameter getParameter method 1");
+    let param = new Parameter("-r");
+    let expected = "-r";
+    let result = param.getParameterName();
+    assert.deepEqual(expected,result);
+}
+
+/**
+ * Tests the isMention method with a mention
+ **/
+function testIsMention1() {
+    console.log("Processing to test the Parameter isMention method 1");
+    let param = new Parameter("<@190878852247767153>");
+    let expected = true;
+    let result = param.isMention();
+    assert.deepEqual(expected,result);
+}
+
+/**
+ * Tests the isMention method with a mention
+ **/
+function testIsMention2() {
+    console.log("Processing to test the Parameter isMention method 2");
+    let param = new Parameter("-r");
+    let expected = false;
+    let result = param.isMention();
+    assert.deepEqual(expected,result);
+}
+
+console.log("Main tests running");
+/**
+ * Add tests here
+ **/
+ 
+ /** Constructor tests **/
+testParameterConstructor1();
+testParameterConstructor2();
+testParameterConstructor3();
+testParameterConstructor4();
+
+/** GetParameterName **/
+testGetParameterName1();
+
+/** IsMention **/
+testIsMention1();
+testIsMention2();
+
+console.log("Main tests completed");
+
+process.exit(0);


### PR DESCRIPTION
Added security on ccm command. You can't use mention anymore as a marker.
Added a parameter class to ease the use of the command class.
